### PR TITLE
Update gnome-all.sqf

### DIFF
--- a/gnome-all.sqf
+++ b/gnome-all.sqf
@@ -33,6 +33,7 @@ avahi
 geoclue2
 libgweather
 gnome-settings-daemon
+blocaled
 
 # Mutter compositor:
 zenity


### PR DESCRIPTION
Add blocaled to main gnome-all.sqf because Gnome Terminal errors out:

# Error constructing proxy for org.gnome.Terminal:/org/gnome/Terminal/Factory0: 
Error calling StartServiceByName for org.gnome.Terminal: Process org.gnome.Terminal exited with status 8
