### PR TITLE
Update gnome-all.sqf queue.

### DIFF
--- a/gnome-all.sqf
+++ b/gnome-all.sqf
@@ -93,8 +93,12 @@ jq
 p7zip
 chrome-gnome-shell
 
-# LibAppIndicator GNOME Shell extension:
+# Some GNOME Shell extensions to include by default:
 gnome-shell-extension-appindicator
+gnome-shell-extension-arc-menu
+gnome-shell-extension-dash-to-panel
+gnome-shell-extension-gsconnect
+gnome-shell-extension-sound-output-device
 
 # GNOME Backgrounds:
 gnome-backgrounds
@@ -167,3 +171,11 @@ seahorse
 
 # GNOME Screenshot:
 gnome-screenshot
+
+# Some games for GNOME:
+libgnome-games-support
+gnome-chess
+gnome-klotski
+gnome-mahjongg
+gnome-mines
+iagno


### PR DESCRIPTION
Adds gsconnect and sound-input-output-chooser extensions as "built-in" extensions.

- GSConnect provides an interface to KDEConnect for GNOME, allowing KDECOnnect to function in a GNOME DE.
- Sound chooser provides slightly more granular control over sound devices from the settings menu.

Added a couple more games for gnome (gtk themed).
- gnome-chess
- gnome-mines

Thanks to Nathaniel Russell for putting these on slackbuilds.org